### PR TITLE
Naming issues and non-puppetmaster fixes

### DIFF
--- a/files/puppet.py
+++ b/files/puppet.py
@@ -27,6 +27,13 @@ def config_hook(conduit):
     global puppet_catalog
     global puppet_packages
     global puppet_yaml
+
+    conduit.registerCommand(InstallRemoveCommand())
+    parser = conduit.getOptParser()
+    if parser:
+        parser.add_option('--allow-removal', dest='allow_removal', action='append', metavar='PKG',
+                          help="Allow removal of PKG, even if puppet says otherwise")
+
     puppet_catalog = conduit.confString('main', 'puppet_catalog', default=puppet_catalog)
     if not os.path.exists(puppet_catalog):
         return
@@ -71,11 +78,6 @@ def config_hook(conduit):
             fd.write(content)
             fd.close()
     puppet_files = [x['title'] for x in files if 'title' in x and 'content' in x]
-    conduit.registerCommand(InstallRemoveCommand())
-    parser = conduit.getOptParser()
-    if parser:
-        parser.add_option('--allow-removal', dest='allow_removal', action='append', metavar='PKG',
-                          help="Allow removal of PKG, even if puppet says otherwise")
 
 def nvra_match(po, pkgs):
     n = po.name

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,16 @@
-class puppet-yum-plugin {
+class yum-puppet-plugin {
     file { "/etc/yum/pluginconf.d/puppet.conf":
         mode    => 0644,
         owner   => root,
         group   => root,
         ensure  => file,
-        source  => "puppet:///modules/yum/puppet.conf",
+        source  => "puppet:///modules/yum-puppet-plugin/puppet.conf",
     }
     file { "/usr/lib/yum-plugins/puppet.py":
         mode    => 0644,
         owner   => root,
         group   => root,
         ensure  => file,
-        source  => "puppet:///modules/yum/puppet.py",
+        source  => "puppet:///modules/yum-puppet-plugin/puppet.py",
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,13 +4,13 @@ class yum_puppet_plugin {
         owner   => root,
         group   => root,
         ensure  => file,
-        source  => "puppet:///modules/yum-puppet-plugin/puppet.conf",
+        source  => "puppet:///modules/yum_puppet_plugin/puppet.conf",
     }
     file { "/usr/lib/yum-plugins/puppet.py":
         mode    => 0644,
         owner   => root,
         group   => root,
         ensure  => file,
-        source  => "puppet:///modules/yum-puppet-plugin/puppet.py",
+        source  => "puppet:///modules/yum_puppet_plugin/puppet.py",
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-class yum-puppet-plugin {
+class yum_puppet_plugin {
     file { "/etc/yum/pluginconf.d/puppet.conf":
         mode    => 0644,
         owner   => root,


### PR DESCRIPTION
This fixes some naming issues to be consistent across the whole plugin, and allows the python yum plugin to still use the install-remove command when there isn't a catalog.
